### PR TITLE
ci(release): remove release creation & enable PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,12 +20,11 @@ jobs:
           release-type: node
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
 
   release:
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force_release }}
+    if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,19 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      force_release:
-        description: Force a release
-        required: true
-        type: boolean
-      force_release_version:
-        description: Version of the release
-        required: false
-        type: string
 
 permissions:
   contents: write
-  id-token: write
   pull-requests: write
 
 jobs:
@@ -28,7 +18,6 @@ jobs:
         id: release
         with:
           release-type: node
-          skip-github-pull-request: true
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -52,10 +41,3 @@ jobs:
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GH Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          append_body: |
-            NPM: https://www.npmjs.com/package/@catppuccin/daisyui/v/${{needs.release-please.outputs.tag_name || inputs.force_release_version}}


### PR DESCRIPTION
A few things in this PR:

- Release please automatically creates releases for you by default so I don't think we need to do our own logic for it.
- I'm not sure why `skip-github-pull-request` has been set but PRs are the flow used by other ports across the organisation. I'm happy to keep this if you can help me understand the reasoning behind it!
- I've removed the force release creation logic because it'll currently conflict with release pleases default behaviour. If a release needs to have its version changed, you can follow the "[How do I change the version number](https://github.com/googleapis/release-please#how-do-i-change-the-version-number)" documentation. If you need to re-release something, you can usually revert the PR and release please should open the PR again.

I think the current state of this file is invalid but it might be valid if `skip-github-release` was set, but again I haven't seen that across the organisation yet. Happy to discuss if you don't agree with my changes here.