### PR TITLE
fix(typo): correct "floder"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note: We do not recommend changing any colors other than the `primary` and `acce
   <button class="btn btn-error">Error</button>
 </div>
 ```
-You can find the example in the `example` floder.
+You can find the example in the `example` folder.
 
 ## 💝 Thanks to
 


### PR DESCRIPTION
There's a typo issue in the README. This PR fixed "floder" to "folder"
